### PR TITLE
Copickier

### DIFF
--- a/src/slabpick/cli/cs_map_back.py
+++ b/src/slabpick/cli/cs_map_back.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from slabpick.csedit import curate_particles_map, curate_particles_map_iterative
 from slabpick.dataio import (
-    CoPickWrangler,
+    CopickInterface,
     combine_star_files,
     make_starfile,
     read_starfile,
@@ -70,12 +70,23 @@ def parse_args():
         required=False,
         help="Copick user ID, required if using copick for coordinates",
     )
-    parser.add_argument("--out_file", type=str, required=True, help="Output starfile")
+    parser.add_argument(
+        "--out_file",
+        type=str,
+        required=True,
+        help="Output starfile")
+    parser.add_argument(
+        "--coords_scale",
+        type=float,
+        required=False,
+        default=1.0,
+        help="Multiplicative factor to convert input coords in starfile(s) to Angstrom"
+    )
     parser.add_argument(
         "--apix",
         type=float,
         required=True,
-        help="Tilt-series pixel size (usually unbinned)",
+        help="Tilt-series pixel size, inverse of this will be applied when writing out starfile",
     )
     parser.add_argument(
         "--rejected_set",
@@ -90,16 +101,16 @@ def main(config):
     # extract all particle coordinates
     if config.in_star:
         d_coords = read_starfile(
-            config.in_star, coords_scale=config.apix, col_name=config.col_name,
+            config.in_star, coords_scale=config.coords_scale, col_name=config.col_name,
         )
     elif config.in_star_multiple:
         d_coords = combine_star_files(
-            config.in_star_multiple, coords_scale=config.apix, col_name=config.col_name,
+            config.in_star_multiple, coords_scale=config.coords_scale, col_name=config.col_name,
         )
     elif config.copick_json:
-        cp_interface = CoPickWrangler(config.copick_json)
+        cp_interface = CopickInterface(config.copick_json)
         d_coords = cp_interface.get_all_coords(
-            config.particle_name, config.session_id, config.user_id,
+            config.particle_name, config.user_id, session_id=config.session_id
         )
     else:
         raise ValueError("Either a copick config or a starfile must be provided.")

--- a/src/slabpick/cli/project_particles.py
+++ b/src/slabpick/cli/project_particles.py
@@ -74,7 +74,7 @@ def parse_args():
         "--session_id",
         type=str,
         required=False,
-        help="Session ID, required if coordinates from copick",
+        help="Session ID, applied if coordinates from copick",
     )
     parser.add_argument(
         "--particle_name",
@@ -185,8 +185,8 @@ def main():
         )
 
     if os.path.splitext(config.in_coords)[-1] == ".json":
-        if None in [config.user_id, config.session_id, config.particle_name]:
-            raise ValueError("Missing session ID and/or particle name")
+        if None in [config.user_id, config.particle_name]:
+            raise ValueError("Missing user ID and/or particle name")
     if os.path.splitext(config.in_vol)[-1] == ".json" and config.tomo_type is None:
         raise ValueError("Missing tomogram type")
     if (

--- a/src/slabpick/minislab.py
+++ b/src/slabpick/minislab.py
@@ -9,7 +9,7 @@ import pandas as pd
 from scipy.ndimage import gaussian_filter
 
 from slabpick.dataio import (
-    CoPickWrangler,
+    CopickInterface,
     combine_star_files,
     load_mrc,
     make_stack_starfile,
@@ -376,9 +376,12 @@ def make_particle_projections(
 
         if len(fnames) > 0:
             # handle different coordinate entrypoints
+            cp_interface = None
             if len(fnames) == 1 and os.path.splitext(in_coords)[-1] == ".json":
-                cp_interface = CoPickWrangler(in_coords)
-                coords = cp_interface.get_all_coords(particle_name, session_id, user_id)
+                cp_interface = CopickInterface(in_coords)
+                coords = cp_interface.get_all_coords(particle_name,
+                                                     user_id,
+                                                     session_id=session_id)
             elif len(fnames) == 1 and os.path.splitext(in_coords)[-1] == ".star":
                 coords = read_starfile(
                     fnames[0], coords_scale=coords_scale, col_name=col_name,
@@ -391,7 +394,8 @@ def make_particle_projections(
             # handle different volume entrypoints
             if os.path.isfile(in_vol):
                 load_method = "copick"
-                cp_interface = CoPickWrangler(in_vol)
+                if cp_interface is None:
+                    cp_interface = CopickInterface(in_vol)
             else:
                 load_method = "mrc"
 


### PR DESCRIPTION
Changes encompass:
- Spring cleaning to eliminate old minislab entry points
- CoPickWrangler -> CopickInterface, updated for data portal compatibility (session_id not required)
- Disambiguated coords_scale (for input coords) and apix (for output coords) in cs_map_back.py (originally curate.py) since input and output coordinates may require different scaling.