### PR TITLE
Miscellaneous updates

### DIFF
--- a/src/slabpick/cli/cs_center_picks.py
+++ b/src/slabpick/cli/cs_center_picks.py
@@ -75,7 +75,8 @@ def main():
         idx = np.where(
             [f"particles_{gn:03}.mrc" in fn.decode("utf-8") for fn in mgraph_id],
         )[0]
-        assert len(idx) > np.prod(gallery_shape)
+        if len(idx) < np.prod(gallery_shape):
+            raise ValueError("Insufficient picks per gallery. Please change blob-pick settings.")
         if i < gnums[-1]:
             retain_idx.extend(list(idx[: np.prod(gallery_shape)]))
         else:

--- a/src/slabpick/cli/make_minislabs.py
+++ b/src/slabpick/cli/make_minislabs.py
@@ -104,6 +104,16 @@ def parse_args():
         help="Number of gallery particles in (row,col) format",
     )
     parser.add_argument(
+        "--make_stack",
+        action="store_true",
+        help="Make particle stack instead of galleries",
+    )
+    parser.add_argument(
+        "--invert_contrast",
+        action="store_true",
+        help="Invert default contrast",
+    )
+    parser.add_argument(
         "--live",
         required=False,
         action="store_true",
@@ -191,6 +201,8 @@ def main():
             col_name=config.col_name,
             angles=config.angles,
             gshape=tuple(config.gallery_shape),
+            make_stack=config.make_stack,
+            invert_contrast=config.invert_contrast,
         )
         
     

--- a/src/slabpick/cli/make_slabs.py
+++ b/src/slabpick/cli/make_slabs.py
@@ -64,7 +64,10 @@ def parse_args():
 
 def main():
     config = parse_args()
-    filenames = np.loadtxt(config.filenames, dtype=str)
+
+    filenames = None
+    if config.filenames:
+        filenames = np.loadtxt(config.filenames, dtype=str)
 
     slabber = Slab(
         config.zthick,

--- a/src/slabpick/cli/rln_map_particles.py
+++ b/src/slabpick/cli/rln_map_particles.py
@@ -73,7 +73,12 @@ def parse_args():
         required=False,
         help="Tilt-series pixel size, inverse of this will be applied if writing out a starfile",
     )
-
+    parser.add_argument(
+        "--rejected_set",
+        action="store_true",
+        help="Extract coordinates of the rejected particles in the star file",
+    )
+    
     return parser.parse_args()
 
 
@@ -92,6 +97,7 @@ def generate_config(config):
         "apix",
         "session_id_out",
         "user_id_out",
+        "rejected_set",
     ]
 
     reconfig = {}
@@ -130,6 +136,9 @@ def main():
     rln_particles = starfile.read(config.rln_file)["particles"]
     indices = np.array([fn.split("@")[0] for fn in rln_particles.rlnImageName.values]).astype(int)
     particles_map = pd.read_csv(config.map_file)
+    if config.rejected_set:
+        print("Selecting the rejected particles")
+        indices = np.setdiff1d(np.arange(len(particles_map)), indices)
     curated_map = particles_map.iloc[indices]
     
     # curate particles, retaining a particle if any of its tilts is selected

--- a/src/slabpick/dataio.py
+++ b/src/slabpick/dataio.py
@@ -434,7 +434,7 @@ class CopickInterface:
         )
 
         if len(picks) == 0:
-            print(f"No picks found for run {run_name}")
+            #print(f"No picks found for run {run_name}")
             return np.empty(0)
         if (user_id is not None) and len(picks) > 1:
             print(

--- a/src/slabpick/settings.py
+++ b/src/slabpick/settings.py
@@ -97,7 +97,7 @@ class ProcessingInputRlnMapParticles(BaseModel):
     rln_file: str
     map_file: str
     coords_file: str
-
+    
     
 class ProcessingOutputRlnMapParticles(BaseModel):
     out_file: str
@@ -110,7 +110,8 @@ class ProcessingParametersRlnMapParticles(BaseModel):
     apix: Optional[float]
     session_id_out: str
     user_id_out: str
-
+    rejected_set: bool
+    
     
 class ProcessingConfigRlnMapParticles(BaseModel):
     software: ProcessingSoftware

--- a/src/slabpick/settings.py
+++ b/src/slabpick/settings.py
@@ -29,6 +29,8 @@ class ProcessingParametersMakeMinislabs(BaseModel):
     particle_name: Optional[str]
     angles: List[int]
     gallery_shape: List[int]
+    make_stack: bool
+    invert_contrast: bool
     live: bool
     t_interval: float
     t_exit: float

--- a/src/slabpick/settings.py
+++ b/src/slabpick/settings.py
@@ -83,6 +83,8 @@ class ProcessingParametersCsMapParticles(BaseModel):
     coords_scale: float
     apix: float
     rejected_set: bool
+    session_id_out: Optional[str]
+    user_id_out: Optional[str]
 
 
 class ProcessingConfigCsMapParticles(BaseModel):
@@ -108,8 +110,8 @@ class ProcessingParametersRlnMapParticles(BaseModel):
     session_id: Optional[str]
     user_id: Optional[str]
     apix: Optional[float]
-    session_id_out: str
-    user_id_out: str
+    session_id_out: Optional[str]
+    user_id_out: Optional[str]
     rejected_set: bool
     
     

--- a/src/slabpick/slab.py
+++ b/src/slabpick/slab.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 import pandas as pd
+from tqdm import tqdm
 
 from slabpick.dataio import get_voxel_size, load_mrc, save_mrc
 
@@ -141,7 +142,7 @@ class Slab:
         self.apix = get_voxel_size(fnames[0])
         zdepth = int(np.around(self.zthick / self.apix))
 
-        for _i, fn in enumerate(fnames):
+        for _i, fn in tqdm(enumerate(fnames)):
             volume = load_mrc(fn)
             volz = volume.shape[0]
             if volz < self.zthick:


### PR DESCRIPTION
Updates include the following:
- more informative error message if there aren't enough picks per gallery
- `cs_map_particles` and `rln_map_particles` can output picks in copick and not just Relion-4 format
- galleries are generated as enough particles are processed to fill a gallery to avoid OOM errors for very large particle sets
- visible borders between minislabs
- option to `--invert_contrast` in generating galleries
- `make_slabs` is fixed for case when filenames are not provided
- `make_minislabs` generates either a particle stack or galleries rather than both