### PR TITLE
Feature: multi-session minislabs

### DIFF
--- a/src/slabpick/cli/make_minislabs.py
+++ b/src/slabpick/cli/make_minislabs.py
@@ -15,12 +15,14 @@ def parse_args():
         "--in_coords",
         type=str,
         required=True,
+        nargs="+",
         help="Coordinate file(s) as one or multiple starfiles or a copick config file",
     )
     parser.add_argument(
         "--in_vol",
         type=str,
         required=False,
+        nargs="*",
         help="Directory containing volumes or a copick config file",
     )
     parser.add_argument(
@@ -41,20 +43,6 @@ def parse_args():
         type=float,
         required=True,
         help="Pixel size of tomograms to extract minislabs from in Angstrom",
-    )
-    parser.add_argument(
-        "--coords_scale",
-        type=float,
-        required=False,
-        default=1,
-        help="Multiplicative factor to convert input coords to Angstrom",
-    )
-    parser.add_argument(
-        "--col_name",
-        type=str,
-        required=False,
-        default="rlnTomoName",
-        help="Tomogram column name in starfile(s)",
     )
     parser.add_argument(
         "--extension",
@@ -114,24 +102,18 @@ def parse_args():
         help="Invert default contrast",
     )
     parser.add_argument(
-        "--live",
+        "--border_factor",
+        type=float,
+        default=1.1,
         required=False,
-        action="store_true",
-        help="Live processing mode, generating one gallery per tomogram",
+        help="Multiplicative factor times mean for gallery border value",
     )
     parser.add_argument(
-        "--t_interval",
+        "--border_width",
+        type=int,
+        default=2,
         required=False,
-        type=float,
-        default=300,
-        help="Interval in seconds between checking for new files",
-    )
-    parser.add_argument(
-        "--t_exit",
-        required=False,
-        type=float,
-        default=1800,
-        help="Interval in seconds after which to exit if new files not found",
+        help="Number of border pixels for around each tile",
     )
 
     return parser.parse_args()
@@ -165,45 +147,24 @@ def main():
     config = parse_args()
     generate_config(config)
 
-    # coordinates provided as multiple starfiles
-    if config.in_coords[-4:] == "star" and "*" in config.in_coords:
-        if not config.live:
-            config.t_interval = config.t_exit = 0
-
-        minislab.make_minislabs_live(
-            config.in_coords,
-            config.in_vol,
-            config.out_dir,
-            config.extract_shape,
-            config.voxel_spacing,
-            config.coords_scale,
-            col_name=config.col_name,
-            angles=config.angles,
-            gshape=tuple(config.gallery_shape),
-            t_interval=config.t_interval,
-            t_exit=config.t_exit,
-        )
-
-    # all other entrypoints
-    else:
-        minislab.make_minislabs_multi_entry(
-            config.in_coords,
-            config.in_vol,
-            config.out_dir,
-            config.extract_shape,
-            config.voxel_spacing,
-            extension=config.extension,
-            tomo_type=config.tomo_type,
-            particle_name=config.particle_name,
-            user_id=config.user_id,
-            session_id=config.session_id,
-            coords_scale=config.coords_scale,
-            col_name=config.col_name,
-            angles=config.angles,
-            gshape=tuple(config.gallery_shape),
-            make_stack=config.make_stack,
-            invert_contrast=config.invert_contrast,
-        )
+    minislab.make_minislabs_multisession(
+        config.in_coords,
+        config.in_vol,
+        config.out_dir,
+        config.extract_shape,
+        config.voxel_spacing,
+        extension=config.extension,
+        tomo_type=config.tomo_type,
+        particle_name=config.particle_name,
+        user_id=config.user_id,
+        session_id=config.session_id,
+        angles=config.angles,
+        gshape=tuple(config.gallery_shape),
+        make_stack=config.make_stack,
+        invert_contrast=config.invert_contrast,
+        border_factor=config.border_factor,
+        border_width=config.border_width,
+    )
         
     
 if __name__ == "__main__":

--- a/src/slabpick/cli/make_minislabs.py
+++ b/src/slabpick/cli/make_minislabs.py
@@ -1,8 +1,6 @@
 import os
 from argparse import ArgumentParser
-
 import slabpick.minislab as minislab
-from slabpick.settings import ProcessingConfigMakeMinislabs
 
 
 def parse_args():
@@ -134,8 +132,6 @@ def generate_config(config):
     used_keys = [p for param in used_keys for p in param]
     param_keys = [key for key in d_config if key not in used_keys]
     reconfig["parameters"] = {k: d_config[k] for k in param_keys}
-
-    reconfig = ProcessingConfigMakeMinislabs(**reconfig)
 
     os.makedirs(config.out_dir, exist_ok=True)
     with open(os.path.join(config.out_dir, "make_minislabs.json"), "w") as f:

--- a/src/slabpick/cli/make_minislabs.py
+++ b/src/slabpick/cli/make_minislabs.py
@@ -135,7 +135,7 @@ def generate_config(config):
 
     os.makedirs(config.out_dir, exist_ok=True)
     with open(os.path.join(config.out_dir, "make_minislabs.json"), "w") as f:
-        f.write(reconfig.model_dump_json(indent=4))
+        json.dump(reconfig, f, indent=4)
 
 
 def main():

--- a/src/slabpick/cli/make_minislabs.py
+++ b/src/slabpick/cli/make_minislabs.py
@@ -1,3 +1,4 @@
+import json
 import os
 from argparse import ArgumentParser
 import slabpick.minislab as minislab

--- a/src/slabpick/cli/rln_map_particles.py
+++ b/src/slabpick/cli/rln_map_particles.py
@@ -3,6 +3,7 @@ import json
 import numpy as np
 import pandas as pd
 import starfile
+from tqdm import tqdm
 from argparse import ArgumentParser
 import slabpick.dataio as dataio
 from copick.impl.filesystem import CopickRootFSSpec
@@ -40,13 +41,13 @@ def parse_args():
     parser.add_argument(
         "--session_id",
         type=str,
-        required=False,
+        required=True,
         help="Copick session ID for input coordinates",
     )
     parser.add_argument(
         "--user_id",
         type=str,
-        required=False,
+        required=True,
         help="Copick user ID for input coordinates",
     )
     parser.add_argument(
@@ -58,7 +59,7 @@ def parse_args():
     parser.add_argument(
         "--session_id_out",
         type=str,
-        required=False,
+        required=True,
         help="Copick session ID for output",
     )
     parser.add_argument(

--- a/src/slabpick/cli/rln_map_particles.py
+++ b/src/slabpick/cli/rln_map_particles.py
@@ -50,12 +50,6 @@ def parse_args():
         help="Copick user ID for input coordinates",
     )
     parser.add_argument(
-        "--out_file",
-        type=str,
-        required=False,
-        help="Output copick json or Relion-4 starfile",
-    )
-    parser.add_argument(
         "--particle_name_out",
         type=str,
         required=False,
@@ -95,7 +89,6 @@ def generate_config(config):
     d_config = vars(config)
 
     input_list = ["rln_file", "map_file", "coords_file"]
-    output_list = ["out_file"]
     parameter_list = [
         "particle_name",
         "session_id",
@@ -110,34 +103,43 @@ def generate_config(config):
     reconfig = {}
     reconfig["software"] = {"name": "slabpick", "version": "0.1.0"}
     reconfig["input"] = {k: d_config[k] for k in input_list}
-    reconfig["output"] = {k: d_config[k] for k in output_list}
     reconfig["parameters"] = {k: d_config[k] for k in parameter_list}
 
-    out_dir = os.path.dirname(os.path.abspath(config.out_file))
+    out_dir = os.path.dirname(os.path.abspath(config.map_file))
     os.makedirs(out_dir, exist_ok=True)
     with open(os.path.join(out_dir, "rln_map_particles.json"), "w") as f:
         json.dump(reconfig, f, indent=4)
 
 
+def curate_data_session(d_coords: dict, curated_map_session: pd.DataFrame) -> dict:
+    """
+    Retain the selected particles from a data session. The curated_map_
+    session should contain only selected particles for one data session.
+    
+    Parameters
+    ----------
+    d_coords: dictionary mapping tomograms to coords
+    curated_map_session: curated particle map for the session
+    
+    Returns
+    -------
+    d_coords_sel: dict mapping tomograms to selected coords
+    """
+    tomo_list = np.unique(curated_map_session.tomogram.values)
+    d_coords_sel = {}
+    for _i, tomo in enumerate(tomo_list):    
+        tomo_indices = np.where(curated_map_session.tomogram.values == tomo)[0]
+        particle_indices = curated_map_session.iloc[tomo_indices].particle.values
+        d_coords_sel[tomo] = d_coords[tomo][np.unique(particle_indices)] 
+    return d_coords_sel
+
+        
 def main():
 
     config = parse_args()
-    if config.out_file is None:
-        config.out_file = config.coords_file
     if config.particle_name_out is None:
         config.particle_name_out = config.particle_name
     generate_config(config)
-    
-    # extract particle coordinates
-    cp_interface = dataio.CopickInterface(config.coords_file)
-    d_coords = cp_interface.get_all_coords(
-        config.particle_name,
-        user_id=config.user_id,
-        session_id=config.session_id,
-    )
-    ini_particle_count = np.sum(
-        np.array([d_coords[tomo].shape[0] for tomo in d_coords]),
-    )
     
     # map retained particles from Relion back to gallery tiles
     rln_particles = starfile.read(config.rln_file)["particles"]
@@ -148,26 +150,44 @@ def main():
         print("Selecting the rejected particles")
         indices = np.setdiff1d(np.arange(len(particles_map)), indices)
     curated_map = particles_map.iloc[indices]
-    
-    # curate particles, retaining a particle if any of its tilts is selected
-    d_coords_sel = {}
-    tomo_list = np.unique(curated_map.tomogram.values)
-    for _i, tomo in enumerate(tomo_list):
-        tomo_indices = np.where(curated_map.tomogram.values == tomo)[0]
-        particle_indices = curated_map.iloc[tomo_indices].particle.values
-        d_coords_sel[tomo] = d_coords[tomo][np.unique(particle_indices)] 
-        final_particle_count = np.sum(np.array([d_coords_sel[tomo].shape[0] for tomo in d_coords_sel]))
-    print(f"Retained {final_particle_count} of {ini_particle_count}",)
 
-    if os.path.splitext(config.out_file)[1] == '.json':
-        print("Writing retained coordinates to a copick experiment")
-        root = CopickRootFSSpec.from_file(config.out_file)
-        dataio.coords_to_copick(root, d_coords_sel, config.particle_name_out, config.session_id_out, config.user_id_out)
-    elif os.path.splitext(config.out_file)[1] == '.star':
-        print("Writing retained coordinates to a Relion-4 star file")
-        dataio.make_starfile(d_coords_sel, config.out_file, coords_scale=1.0/config.apix)
+    # retrieve sessions that will be used and write parameter config
+    if 'session' not in particles_map.columns:
+        if config.coords_file is None:
+            raise ValueError("The --coords_file must be specified")
+        session_list = [config.coords_file]
     else:
-        raise ValueError(f"Unrecognized output argument, should be copick json or starfile")
+        session_list = np.unique(curated_map.session.values)
+    config.coords_file = list(session_list)
+    generate_config(config)
+
+    # loop over data sessions
+    counts = 0
+    for sconfig in tqdm(session_list):
+        # get original coordinates
+        cp_interface = dataio.CopickInterface(sconfig)
+        d_coords = cp_interface.get_all_coords(
+            config.particle_name,
+            user_id=config.user_id,
+            session_id=config.session_id,
+        )
+        ini_particle_count = np.sum(np.array([d_coords[tomo].shape[0] for tomo in d_coords]),)
+
+        # curate coordinates, retaining only the selected particles
+        if 'session' not in particles_map.columns:
+            curated_map_session = curated_map
+        else:
+            curated_map_session = curated_map[curated_map.session==sconfig]
+        d_coords_sel = curate_data_session(d_coords, curated_map_session)
+        final_particle_count = np.sum(np.array([d_coords_sel[tomo].shape[0] for tomo in d_coords_sel]))
+        print(f"Retained {final_particle_count} of {ini_particle_count} from {sconfig}",)
+        counts += final_particle_count
+
+        # write retained coordinates to copick project
+        root = CopickRootFSSpec.from_file(sconfig)
+        dataio.coords_to_copick(root, d_coords_sel, config.particle_name_out, config.session_id_out, config.user_id_out)
+
+    assert counts == len(rln_particles)
 
     
 if __name__ == "__main__":

--- a/src/slabpick/cli/rln_map_particles.py
+++ b/src/slabpick/cli/rln_map_particles.py
@@ -29,7 +29,7 @@ def parse_args():
     parser.add_argument(
         "--coords_file",
         type=str,
-        required=True,
+        required=False,
         help="Copick json file specifying coordinates",
     )
     parser.add_argument(


### PR DESCRIPTION
The `make_minislabs` and `rln_map_particles` CLI tools have bene updated to accommodate multi-session datasets, where each dataset is specified in a different copick session. For the `rln_map_particles` step, the `--coords_file` input should not be supplied since the copick config file will be pulled from the map_particles.csv file.