### PR TITLE
fix: skip runs with missing voxel spacing in copick minislab generation

### DIFF
--- a/src/slabpick/dataio.py
+++ b/src/slabpick/dataio.py
@@ -399,7 +399,10 @@ class CopickInterface:
         array: volume
         """
         run = self.root.get_run(run_name)
-        tomogram = run.get_voxel_spacing(voxel_spacing).get_tomogram(
+        vs = run.get_voxel_spacing(voxel_spacing)
+        if vs is None:
+            return None
+        tomogram = vs.get_tomogram(
             tomo_type=tomo_type,
         )
         return tomogram.numpy()

--- a/src/slabpick/minislab.py
+++ b/src/slabpick/minislab.py
@@ -546,6 +546,8 @@ def make_minislabs_multisession(
             # load volume -- copick entry
             else:
                 volume = cp_interface.get_run_tomogram(run_name, voxel_spacing, tomo_type)
+                if volume is None:
+                    continue
             coords_pixels = d_coords[run_name] / voxel_spacing
             montage.make_minislabs(coords_pixels, volume, run_name, cp_project)
 


### PR DESCRIPTION
## Summary

- `CopickInterface.get_run_tomogram` now returns `None` instead of
  crashing when `get_voxel_spacing` returns `None` (run lacks tomogram
  data at the requested voxel spacing)
- `make_minislabs_multisession` skips runs where the volume is `None`
  rather than attempting to process them

## Motivation

Previously, if a run in a copick project did not have tomogram data at
the requested voxel spacing, `get_voxel_spacing` would return `None`
and the chained `.get_tomogram(...)` call would raise an
`AttributeError`, aborting minislab generation for all subsequent runs.
These changes allow the pipeline to gracefully skip incomplete runs
instead.