### PR TITLE
account for Relion's enforced 1-indexing of stack

### DIFF
--- a/src/slabpick/cli/rln_map_particles.py
+++ b/src/slabpick/cli/rln_map_particles.py
@@ -143,8 +143,12 @@ def main():
     generate_config(config)
     
     # map retained particles from Relion back to gallery tiles
+    # note that the starfile written by slabpick is 0-indexed
+    # however, Relion ignores this to enforce 1-indexing, which
+    # means that the indices have to be modified to account for this
+    print("Adjusting for Relion's enforcement of 1-indexing")
     rln_particles = starfile.read(config.rln_file)["particles"]
-    indices = np.array([fn.split("@")[0] for fn in rln_particles.rlnImageName.values]).astype(int)
+    indices = np.array([fn.split("@")[0] for fn in rln_particles.rlnImageName.values]).astype(int) - 1
     particles_map = pd.read_csv(config.map_file)
     particles_map['tomogram'] = particles_map['tomogram'].astype(str)
     if config.rejected_set:


### PR DESCRIPTION
The particles starfile output by slabpick is 0-indexed, with the first particle labeled as "0@particles_relion.mrcs". However, Relion-5 forces 1-indexing on top of this, causing the first particle in the stack to be indexed as the last element due to wrapping (0 -> -1). The mapping back function was written assuming that the 0-indexing was retained and has been corrected to account for this.